### PR TITLE
separate dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
   "dependencies": {
     "hogan.js": "~3.0.2",
     "node-gettext": "~0.2.14",
-    "nodeunit": "~0.9.0",
     "walkdir": "0.0.7"
+  },
+  "devDependencies": {
+    "nodeunit": "~0.9.0"
   }
 }


### PR DESCRIPTION
Move nodeunit out to devDependency so that it won't be compiled to the front end bundle as it contains security issues and is not needed to be served anyways.